### PR TITLE
Suppression de docker et installation de cups-client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt update && \
 
 RUN apt install -y --no-install-recommends \
         cron \
-        docker.io \
+        cups-client \
         fontconfig \
         g++ \
         git \


### PR DESCRIPTION
Plutôt que de lancer une commande d'impression sur le conteneur `sf4_cups` en passant par Docker sur `sf4_php`, `sf4_php` sera simplement un client puisque `sf4_cups` est un serveur. À l'issue de cette _pull_, pourrons être supprimés le tag `cups-client` de l'image `marcodec/tc_php` (qui était utilisé temporairement le temps de valider les modifications sur mobile — maintenant qu'elles sont fusionnées, on peut tout mettre sur le `latest`) et l'image `marcodec/tc_cups`, remplacée par `olbat/cupsd`.